### PR TITLE
feat: include custom configuration for the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import (
 
 func main() {
     client := nntpcli.New()
-    conn, err := client.Dial(context.Background(), "news.example.com", 119, time.Now().Add(5*time.Second))
+    conn, err := client.Dial(context.Background(), "news.example.com", 119, nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/config.go
+++ b/config.go
@@ -6,15 +6,17 @@ import (
 )
 
 type Config struct {
-	log     *slog.Logger
-	timeout time.Duration
+	// Logger is the logger used by the client.
+	Logger *slog.Logger
+	// KeepAliveTime is the time that the client will keep the connection alive.
+	KeepAliveTime time.Duration
 }
 
 type Option func(*Config)
 
 var configDefault = Config{
-	timeout: time.Duration(5) * time.Second,
-	log:     slog.Default(),
+	KeepAliveTime: 10 * time.Minute,
+	Logger:        slog.Default(),
 }
 
 func mergeWithDefault(config ...Config) Config {
@@ -24,12 +26,12 @@ func mergeWithDefault(config ...Config) Config {
 
 	cfg := config[0]
 
-	if cfg.timeout == 0 {
-		cfg.timeout = configDefault.timeout
+	if cfg.KeepAliveTime == 0 {
+		cfg.KeepAliveTime = configDefault.KeepAliveTime
 	}
 
-	if cfg.log == nil {
-		cfg.log = configDefault.log
+	if cfg.Logger == nil {
+		cfg.Logger = configDefault.Logger
 	}
 
 	return cfg

--- a/connection_mock.go
+++ b/connection_mock.go
@@ -50,18 +50,18 @@ func (mr *MockConnectionMockRecorder) Authenticate(username, password interface{
 }
 
 // BodyDecoded mocks base method.
-func (m *MockConnection) BodyDecoded(msgId string, w io.Writer, discard int64) (int64, error) {
+func (m *MockConnection) BodyDecoded(msgID string, w io.Writer, discard int64) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BodyDecoded", msgId, w, discard)
+	ret := m.ctrl.Call(m, "BodyDecoded", msgID, w, discard)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BodyDecoded indicates an expected call of BodyDecoded.
-func (mr *MockConnectionMockRecorder) BodyDecoded(msgId, w, discard interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) BodyDecoded(msgID, w, discard interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BodyDecoded", reflect.TypeOf((*MockConnection)(nil).BodyDecoded), msgId, w, discard)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BodyDecoded", reflect.TypeOf((*MockConnection)(nil).BodyDecoded), msgID, w, discard)
 }
 
 // Capabilities mocks base method.
@@ -150,16 +150,16 @@ func (mr *MockConnectionMockRecorder) Post(r interface{}) *gomock.Call {
 }
 
 // Stat mocks base method.
-func (m *MockConnection) Stat(msgId string) (int, error) {
+func (m *MockConnection) Stat(msgID string) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stat", msgId)
+	ret := m.ctrl.Call(m, "Stat", msgID)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Stat indicates an expected call of Stat.
-func (mr *MockConnectionMockRecorder) Stat(msgId interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) Stat(msgID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockConnection)(nil).Stat), msgId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockConnection)(nil).Stat), msgID)
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -69,6 +69,48 @@ func TestConnection_Body_Discarding_Bytes(t *testing.T) {
 	assert.Equal(t, int64(4), n)
 }
 
+func TestConnection_Capabilities(t *testing.T) {
+	conn := articleReadyToDownload(t)
+
+	// Test getting capabilities
+	caps, err := conn.Capabilities()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, caps)
+
+	// Test capabilities response format
+	for _, cap := range caps {
+		assert.NotEmpty(t, cap)
+	}
+}
+
+func TestConnection_Stat(t *testing.T) {
+	conn := articleReadyToDownload(t)
+
+	// Test successful stat
+	number, err := conn.Stat("1234")
+	assert.NoError(t, err)
+	assert.Greater(t, number, 0)
+
+	// Test stat with invalid message ID
+	_, err = conn.Stat("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestConnection_Post_Error(t *testing.T) {
+	conn := articleReadyToDownload(t)
+
+	// Test posting invalid article
+	invalidPost := bytes.NewBufferString("invalid post content")
+	err := conn.Post(invalidPost)
+	assert.Error(t, err)
+
+	// Test posting with closed writer
+	r, w := io.Pipe()
+	w.Close()
+	err = conn.Post(r)
+	assert.Error(t, err)
+}
+
 func articleReadyToDownload(t *testing.T) Connection {
 	wg := &sync.WaitGroup{}
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -107,7 +107,9 @@ func TestConnection_Post_Error(t *testing.T) {
 	// Test posting with closed writer
 	r, w := io.Pipe()
 	w.Close()
+
 	err = conn.Post(r)
+
 	assert.Error(t, err)
 }
 

--- a/nntp_mock.go
+++ b/nntp_mock.go
@@ -36,31 +36,31 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Dial mocks base method.
-func (m *MockClient) Dial(ctx context.Context, host string, port int, maxAgeTime time.Time) (Connection, error) {
+func (m *MockClient) Dial(ctx context.Context, host string, port int, dialTimeout *time.Duration) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", ctx, host, port, maxAgeTime)
+	ret := m.ctrl.Call(m, "Dial", ctx, host, port, dialTimeout)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dial indicates an expected call of Dial.
-func (mr *MockClientMockRecorder) Dial(ctx, host, port, maxAgeTime interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Dial(ctx, host, port, dialTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), ctx, host, port, maxAgeTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), ctx, host, port, dialTimeout)
 }
 
 // DialTLS mocks base method.
-func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, maxAgeTime time.Time) (Connection, error) {
+func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, dialTimeout *time.Duration) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DialTLS", ctx, host, port, insecureSSL, maxAgeTime)
+	ret := m.ctrl.Call(m, "DialTLS", ctx, host, port, insecureSSL, dialTimeout)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DialTLS indicates an expected call of DialTLS.
-func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL, maxAgeTime interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL, dialTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), ctx, host, port, insecureSSL, maxAgeTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), ctx, host, port, insecureSSL, dialTimeout)
 }

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -2,6 +2,7 @@ package nntpcli
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"strconv"
 	"strings"
@@ -18,13 +19,11 @@ func TestDial(t *testing.T) {
 	assert.NoError(t, e)
 
 	var mx sync.RWMutex
-
 	closed := false
 
 	defer func() {
 		mx.Lock()
 		closed = true
-
 		mockServer.Close()
 		mx.Unlock()
 	}()
@@ -55,18 +54,188 @@ func TestDial(t *testing.T) {
 	port, err := strconv.Atoi(s[1])
 	assert.NoError(t, err)
 
-	// create a client and dial the mock server
+	// Test successful connection
 	t.Run("Dial", func(t *testing.T) {
-		c := &client{timeout: 5 * time.Second}
-		conn, err := c.Dial(context.Background(), host, port, time.Now().Add(5*time.Second))
+		c := &client{keepAliveTime: 5 * time.Second}
+		dialTimeout := 5 * time.Second
+		conn, err := c.Dial(context.Background(), host, port, &dialTimeout)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		assert.True(t, conn.MaxAgeTime().After(time.Now()))
+	})
+
+	// Test connection to non-existent server
+	t.Run("DialFail", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		dialTimeout := 5 * time.Second
+		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, &dialTimeout)
+		assert.Error(t, err)
+	})
+
+	// Test connection with nil timeout
+	t.Run("DialWithNilTimeout", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		conn, err := c.Dial(context.Background(), host, port, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
 
-	// create a client and dial a non-existent server
-	t.Run("DialFail", func(t *testing.T) {
-		c := &client{timeout: 5 * time.Second}
-		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, time.Now().Add(5*time.Second))
+	// Test connection with zero timeout
+	t.Run("DialWithZeroTimeout", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		zeroTimeout := time.Duration(0)
+		conn, err := c.Dial(context.Background(), host, port, &zeroTimeout)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+	})
+
+	// Test connection with canceled context
+	t.Run("DialWithCanceledContext", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		dialTimeout := 5 * time.Second
+		_, err := c.Dial(ctx, host, port, &dialTimeout)
 		assert.Error(t, err)
 	})
 }
+
+func TestDialTLS(t *testing.T) {
+	// create a mock TLS server
+	cert, err := tls.X509KeyPair([]byte(testCert), []byte(testKey))
+	assert.NoError(t, err)
+
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	mockServer, e := tls.Listen("tcp", "127.0.0.1:0", config)
+	assert.NoError(t, e)
+
+	var mx sync.RWMutex
+	closed := false
+
+	defer func() {
+		mx.Lock()
+		closed = true
+		mockServer.Close()
+		mx.Unlock()
+	}()
+
+	// create a goroutine to accept incoming connections
+	go func() {
+		for {
+			mx.RLock()
+			if closed {
+				mx.RUnlock()
+				return
+			}
+			mx.RUnlock()
+
+			conn, err := mockServer.Accept()
+			if err != nil {
+				return
+			}
+
+			_, _ = conn.Write([]byte("200 mock server ready\r\n"))
+			conn.Close()
+		}
+	}()
+
+	s := strings.Split(mockServer.Addr().String(), ":")
+	host := s[0]
+
+	port, err := strconv.Atoi(s[1])
+	assert.NoError(t, err)
+
+	// Test successful TLS connection with insecure SSL
+	t.Run("DialTLS", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		dialTimeout := 5 * time.Second
+		conn, err := c.DialTLS(context.Background(), host, port, true, &dialTimeout)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		assert.True(t, conn.MaxAgeTime().After(time.Now()))
+	})
+
+	// Test TLS connection with secure SSL (should fail with self-signed cert)
+	t.Run("DialTLSSecure", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		dialTimeout := 5 * time.Second
+		_, err := c.DialTLS(context.Background(), host, port, false, &dialTimeout)
+		assert.Error(t, err)
+	})
+
+	// Test TLS connection with nil timeout
+	t.Run("DialTLSWithNilTimeout", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		conn, err := c.DialTLS(context.Background(), host, port, true, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+	})
+
+	// Test TLS connection with canceled context
+	t.Run("DialTLSWithCanceledContext", func(t *testing.T) {
+		c := &client{keepAliveTime: 5 * time.Second}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		dialTimeout := 5 * time.Second
+		_, err := c.DialTLS(ctx, host, port, true, &dialTimeout)
+		assert.Error(t, err)
+	})
+}
+
+// Self-signed test certificate and key
+const testCert = `-----BEGIN CERTIFICATE-----
+MIIDzzCCAregAwIBAgIUVN8hNBbQkGt61hGioSVvFVfsKOcwDQYJKoZIhvcNAQEL
+BQAwdjELMAkGA1UEBhMCZXMxDTALBgNVBAgMBHRlc3QxDTALBgNVBAcMBHRlc3Qx
+DTALBgNVBAoMBHRlc3QxDTALBgNVBAsMBHRlc3QxDTALBgNVBAMMBHRlc3QxHDAa
+BgkqhkiG9w0BCQEWDXRlc3RAdGVzdC5jb20wIBcNMjUwMTI0MDczNDQ1WhgPMjA1
+MDA5MTUwNzM0NDVaMHYxCzAJBgNVBAYTAmVzMQ0wCwYDVQQIDAR0ZXN0MQ0wCwYD
+VQQHDAR0ZXN0MQ0wCwYDVQQKDAR0ZXN0MQ0wCwYDVQQLDAR0ZXN0MQ0wCwYDVQQD
+DAR0ZXN0MRwwGgYJKoZIhvcNAQkBFg10ZXN0QHRlc3QuY29tMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyKWSwJDdGKNrvi6IA9h3X7DLof5iKM8tOU5J
+9ykkYCr+uEvtW90SJBSPbgJ0pI1AfVBIqteTDsuUpg1pmzLGh0iQZxziVxkNzBEQ
+Guz1/6bfJVkXHdUHPR06lLuH8NHEVTEm9/6BJpSmsOxlVA1gZXKdTRuUqKerjcZ9
+HMyCF/Y2UNZhsx/BmTuxZDyWkwTnjNg8/v+pIpb2ea3pPhO02tQ3GKEwH9FoyBIu
+5z89e0fGxo1Fj0XtziWqn2jXbwSKpnwrbXofAF4mhL10hkoeMJ5ckW1z067PTTOv
+OGhGDknSMqYsuUil5UZZtuTkbbFFKi8D1ofA/7mfzifEnpM1kwIDAQABo1MwUTAd
+BgNVHQ4EFgQUJGLoWiLT31mqL20z9VsY8JnAlOswHwYDVR0jBBgwFoAUJGLoWiLT
+31mqL20z9VsY8JnAlOswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAKoky4qxpt9kmnKHyNF6ZrBm7Cpw4ZhFyVUP0LpFenUv6ecGwW5mxR2ComMxP
+xCjXA0Yq2mTETCwrqi81ZFNhXfvJEPamUrQ7bATvPZzDPviaKrxPdkek/SqBtU3s
+VZppxe7Sc+MC4ds65HwevwopE+mPoe5fMGVs81G4tI9oCF1XPuAe4fiOl33YEcW2
+4qAyCEaZ6SIi4WsAsOaTYhijE/5ud3vHvx4ZWC+nwRbCumm6MWdtLPLWZa6CbqZB
+jHQNAe+ih8Br8Nrh1uyZOB2q2t0RbcfClGIunjR8cm9id9IuAvEaNVNzR3jyKRQH
+wub2PjUzKSWOKr770AmAUb19Pg==
+-----END CERTIFICATE-----
+`
+
+const testKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIpZLAkN0Yo2u+
+LogD2HdfsMuh/mIozy05Tkn3KSRgKv64S+1b3RIkFI9uAnSkjUB9UEiq15MOy5Sm
+DWmbMsaHSJBnHOJXGQ3MERAa7PX/pt8lWRcd1Qc9HTqUu4fw0cRVMSb3/oEmlKaw
+7GVUDWBlcp1NG5Sop6uNxn0czIIX9jZQ1mGzH8GZO7FkPJaTBOeM2Dz+/6kilvZ5
+rek+E7Ta1DcYoTAf0WjIEi7nPz17R8bGjUWPRe3OJaqfaNdvBIqmfCtteh8AXiaE
+vXSGSh4wnlyRbXPTrs9NM684aEYOSdIypiy5SKXlRlm25ORtsUUqLwPWh8D/uZ/O
+J8SekzWTAgMBAAECggEABgR9NbxCfUItcYs4thDQZ7TILqgP7pRkEVNpQXng5udz
+MzjHuhkTubRKJuz47ZR06i01uLX1aZyubRp639YygQ0qk4UYvq74LHYYiw4vRIcP
+KzIUUOc6K9mMD7jeF1lbL4jlV8uwuOT9aNH2KgKqsPAyioT4vOQmb36T8wCpKCnD
+DKwXA0AV40iBnDAoZlixBkwf8De5wcYC63zOGJ+i9th0ujovW8Ds+UuUb+fbpXrz
+gq8Uk3zuvEhrczRwaK+bDaR6PW3g4jy96FcMVjtSJdigRG+UEGnZC3pvt8cGwvoH
+iMFF8xQfF31OPPJNEt4Z5nVebuZbE9pc0vPAQdFXGQKBgQD1xC+P8abHcC2MXOU1
+QI1ppxBHlBE58SZcpGxG6TG2rdiMvM0oq7VUuCnQ9GimoMuDAdD9YlfbRAb2VENH
+KTrCiu8kk7/6dkbmMpwMCw/S1VkGHFaysYdvWY9PC+284DqkubmZsigaXdWYVsVr
+S+lJ8tDXwrQzoHsa27T/NZtJ6QKBgQDRAGw/1cc8zHauepMm5+m8KC/+wDi+UXIS
+1RjKdPVStUvz/UfOrIjesoOGlmPFHLQC9ADSrxxH6aK+gG6d/1KjzTQVYpndq4xC
+VDhfpzsGwoVW1w32eHQpI/dRO44yshdyZqZHkbNPmeI8XFc3VdtrFylvtKS7QcBJ
+g3fjfPLaGwKBgQCfDd7yO6SCQllYE+7LLgHXNKXWjT8wzp7TKh5hLh5cadpSCwaD
+oczzDVUSxHrODBZprM1Cj1josPgIh7Qa49YBfcUTWQPP5qgv5uUS7j3JZwX8bG63
+qylJqR6UO9YafMu3O/OgQqqtlbjcpJuTu0c58omyeXICT4Qcd8CFwn3DsQKBgGrg
+1nqGbg6PWJm9IQciTYrk2jZiQiJBMB6lTropuVKEV8T73v63iH6pt0zaF0czeHKS
+KOGUnte/iHP25ZpyeOY/B8Vv2NNc6Kr6uqFfuXWpf9p6uy8xReXL+KtX003leMwN
+5jZvMc0hGmpXplor07sd6xiuvhbsdtKhImv494/FAoGASZYOdE7amobY5Kpm6lbE
+g4jbgkZQvDOhCebwcWVcxL/F8tSZcHWdhmaX4Q9A5+8EF9W/0nZPImB54rwQJ6DN
+e2MC+FKfM4FUxfPXzTz8DMkhrbyD8v7MfVnpLBZSOfuB9xvB7ZQu2qALmKm4OPiN
+GcILtt7C97hQjjUJsURDFhA=
+-----END PRIVATE KEY-----`

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -19,11 +19,14 @@ func TestDial(t *testing.T) {
 	assert.NoError(t, e)
 
 	var mx sync.RWMutex
+
 	closed := false
 
 	defer func() {
 		mx.Lock()
+
 		closed = true
+
 		mockServer.Close()
 		mx.Unlock()
 	}()
@@ -94,7 +97,9 @@ func TestDial(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
+
 		dialTimeout := 5 * time.Second
+
 		_, err := c.Dial(ctx, host, port, &dialTimeout)
 		assert.Error(t, err)
 	})
@@ -109,15 +114,18 @@ func TestDialTLS(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	mockServer, e := tls.Listen("tcp", "127.0.0.1:0", config)
-	assert.NoError(t, e)
+	mockServer, err := tls.Listen("tcp", "127.0.0.1:0", config)
+	assert.NoError(t, err)
 
 	var mx sync.RWMutex
+
 	closed := false
 
 	defer func() {
 		mx.Lock()
+
 		closed = true
+
 		mockServer.Close()
 		mx.Unlock()
 	}()
@@ -132,8 +140,8 @@ func TestDialTLS(t *testing.T) {
 			}
 			mx.RUnlock()
 
-			conn, err := mockServer.Accept()
-			if err != nil {
+			conn, e := mockServer.Accept()
+			if e != nil {
 				return
 			}
 
@@ -177,9 +185,12 @@ func TestDialTLS(t *testing.T) {
 	// Test TLS connection with canceled context
 	t.Run("DialTLSWithCanceledContext", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
+
 		dialTimeout := 5 * time.Second
+
 		_, err := c.DialTLS(ctx, host, port, true, &dialTimeout)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
This pull request includes several changes to the NNTP client library, focusing on improving the configuration, connection handling, and adding comprehensive tests. The most important changes include updating the `Config` struct, modifying the `Dial` and `DialTLS` methods, and adding new test cases.

### Configuration Updates:
* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L9-R19): The `Config` struct has been updated to replace `timeout` with `KeepAliveTime` and `log` with `Logger`. This change also includes updating the default configuration values. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L9-R19) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L27-R34)

### Connection Handling:
* [`nntp.go`](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L23-R49): The `Dial` and `DialTLS` methods now accept a `dialTimeout` parameter instead of `maxAgeTime`. The keep-alive period is set using `KeepAliveTime` from the configuration. [[1]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L23-R49) [[2]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L55-R63) [[3]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L69-R75) [[4]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L90-R101) [[5]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L104-R113) [[6]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L117-R135)

### Testing Enhancements:
* [`connection_test.go`](diffhunk://#diff-b490092874a7d23daa711d51e772d0e7196b4337067351af81b448c6901ce377R72-R113): Added new test cases for connection capabilities, stat, and post error scenarios.
* [`nntp_test.go`](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aR5): Expanded test coverage to include various scenarios for `Dial` and `DialTLS` methods, including nil timeout, zero timeout, and canceled context. [[1]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aR5) [[2]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL21-L27) [[3]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL58-R241)

### Other Changes:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35): Updated the example code to reflect the changes in the `Dial` method, removing the `maxAgeTime` parameter.