### PR TITLE
feat: add keep alive in dial methods

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,13 +1,10 @@
 package nntpcli
 
 import (
-	"log/slog"
 	"time"
 )
 
 type Config struct {
-	// Logger is the logger used by the client.
-	Logger *slog.Logger
 	// KeepAliveTime is the time that the client will keep the connection alive.
 	KeepAliveTime time.Duration
 }
@@ -16,7 +13,6 @@ type Option func(*Config)
 
 var configDefault = Config{
 	KeepAliveTime: 10 * time.Minute,
-	Logger:        slog.Default(),
 }
 
 func mergeWithDefault(config ...Config) Config {
@@ -28,10 +24,6 @@ func mergeWithDefault(config ...Config) Config {
 
 	if cfg.KeepAliveTime == 0 {
 		cfg.KeepAliveTime = configDefault.KeepAliveTime
-	}
-
-	if cfg.Logger == nil {
-		cfg.Logger = configDefault.Logger
 	}
 
 	return cfg

--- a/nntp.go
+++ b/nntp.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log/slog"
 	"net"
 	"time"
 )
@@ -34,7 +33,6 @@ type Client interface {
 }
 
 type client struct {
-	log           *slog.Logger
 	keepAliveTime time.Duration
 }
 
@@ -47,7 +45,6 @@ func New(
 	config := mergeWithDefault(c...)
 
 	return &client{
-		log:           config.Logger,
 		keepAliveTime: config.KeepAliveTime,
 	}
 }

--- a/nntp.go
+++ b/nntp.go
@@ -87,9 +87,9 @@ func (c *client) Dial(
 	if keepAliveTime != nil {
 		keepAlive = *keepAliveTime
 	}
+
 	err = conn.(*net.TCPConn).SetKeepAlivePeriod(keepAlive)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 
@@ -143,9 +143,9 @@ func (c *client) DialTLS(
 	if keepAliveTime != nil {
 		keepAlive = *keepAliveTime
 	}
+
 	err = conn.(*net.TCPConn).SetKeepAlivePeriod(keepAlive)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 

--- a/nntp_mock.go
+++ b/nntp_mock.go
@@ -36,31 +36,31 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Dial mocks base method.
-func (m *MockClient) Dial(ctx context.Context, host string, port int, dialTimeout *time.Duration) (Connection, error) {
+func (m *MockClient) Dial(ctx context.Context, host string, port int, keepAliveTime, dialTimeout *time.Duration) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", ctx, host, port, dialTimeout)
+	ret := m.ctrl.Call(m, "Dial", ctx, host, port, keepAliveTime, dialTimeout)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dial indicates an expected call of Dial.
-func (mr *MockClientMockRecorder) Dial(ctx, host, port, dialTimeout interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Dial(ctx, host, port, keepAliveTime, dialTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), ctx, host, port, dialTimeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), ctx, host, port, keepAliveTime, dialTimeout)
 }
 
 // DialTLS mocks base method.
-func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, dialTimeout *time.Duration) (Connection, error) {
+func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, keepAliveTime, dialTimeout *time.Duration) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DialTLS", ctx, host, port, insecureSSL, dialTimeout)
+	ret := m.ctrl.Call(m, "DialTLS", ctx, host, port, insecureSSL, keepAliveTime, dialTimeout)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DialTLS indicates an expected call of DialTLS.
-func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL, dialTimeout interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL, keepAliveTime, dialTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), ctx, host, port, insecureSSL, dialTimeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), ctx, host, port, insecureSSL, keepAliveTime, dialTimeout)
 }

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -61,24 +61,26 @@ func TestDial(t *testing.T) {
 	t.Run("Dial", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		dialTimeout := 5 * time.Second
-		conn, err := c.Dial(context.Background(), host, port, &dialTimeout)
+		keepAliveTime := 10 * time.Second
+		conn, err := c.Dial(context.Background(), host, port, &keepAliveTime, &dialTimeout)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 		assert.True(t, conn.MaxAgeTime().After(time.Now()))
+		assert.True(t, conn.MaxAgeTime().After(time.Now().Add(9*time.Second)))
 	})
 
 	// Test connection to non-existent server
 	t.Run("DialFail", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		dialTimeout := 5 * time.Second
-		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, &dialTimeout)
+		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, nil, &dialTimeout)
 		assert.Error(t, err)
 	})
 
 	// Test connection with nil timeout
 	t.Run("DialWithNilTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		conn, err := c.Dial(context.Background(), host, port, nil)
+		conn, err := c.Dial(context.Background(), host, port, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -87,7 +89,7 @@ func TestDial(t *testing.T) {
 	t.Run("DialWithZeroTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		zeroTimeout := time.Duration(0)
-		conn, err := c.Dial(context.Background(), host, port, &zeroTimeout)
+		conn, err := c.Dial(context.Background(), host, port, nil, &zeroTimeout)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -100,7 +102,7 @@ func TestDial(t *testing.T) {
 
 		dialTimeout := 5 * time.Second
 
-		_, err := c.Dial(ctx, host, port, &dialTimeout)
+		_, err := c.Dial(ctx, host, port, nil, &dialTimeout)
 		assert.Error(t, err)
 	})
 }
@@ -160,7 +162,8 @@ func TestDialTLS(t *testing.T) {
 	t.Run("DialTLS", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		dialTimeout := 5 * time.Second
-		conn, err := c.DialTLS(context.Background(), host, port, true, &dialTimeout)
+		keepAliveTime := 10 * time.Second
+		conn, err := c.DialTLS(context.Background(), host, port, true, &keepAliveTime, &dialTimeout)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 		assert.True(t, conn.MaxAgeTime().After(time.Now()))
@@ -170,14 +173,14 @@ func TestDialTLS(t *testing.T) {
 	t.Run("DialTLSSecure", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
 		dialTimeout := 5 * time.Second
-		_, err := c.DialTLS(context.Background(), host, port, false, &dialTimeout)
+		_, err := c.DialTLS(context.Background(), host, port, false, nil, &dialTimeout)
 		assert.Error(t, err)
 	})
 
 	// Test TLS connection with nil timeout
 	t.Run("DialTLSWithNilTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		conn, err := c.DialTLS(context.Background(), host, port, true, nil)
+		conn, err := c.DialTLS(context.Background(), host, port, true, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -191,7 +194,7 @@ func TestDialTLS(t *testing.T) {
 
 		dialTimeout := 5 * time.Second
 
-		_, err := c.DialTLS(ctx, host, port, true, &dialTimeout)
+		_, err := c.DialTLS(ctx, host, port, true, nil, &dialTimeout)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
This pull request enhances the `nntp` package by adding support for an optional keep-alive time parameter in the `Dial` and `DialTLS` methods. Additionally, it updates the corresponding tests to accommodate these changes.

Key changes include:

### Enhancements to `Dial` and `DialTLS` methods:
* Added an optional `keepAliveTime` parameter to the `Dial` and `DialTLS` methods in the `Client` interface and their implementations. This parameter allows overriding the default keep-alive time. [[1]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265R23-R31) [[2]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L53-R71) [[3]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L75-R93) [[4]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L86-R127) [[5]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L113-R149) [[6]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L134-R170)

### Updates to test cases:
* Modified the `TestDial` and `TestDialTLS` test cases to include the new `keepAliveTime` parameter, ensuring that the new functionality is properly tested. [[1]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL64-R83) [[2]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL90-R92) [[3]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL103-R105) [[4]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL163-R166) [[5]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL173-R183) [[6]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL194-R197)