### PR TITLE
feat: improve dial input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import (
 
 func main() {
     client := nntpcli.New()
-    conn, err := client.Dial(context.Background(), "news.example.com", 119, nil)
+    conn, err := client.Dial(context.Background(), "news.example.com", 119)
     if err != nil {
         log.Fatal(err)
     }

--- a/nntp_mock.go
+++ b/nntp_mock.go
@@ -12,7 +12,6 @@ package nntpcli
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "go.uber.org/mock/gomock"
 )
@@ -42,31 +41,41 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Dial mocks base method.
-func (m *MockClient) Dial(ctx context.Context, host string, port int, keepAliveTime, dialTimeout *time.Duration) (Connection, error) {
+func (m *MockClient) Dial(ctx context.Context, host string, port int, config ...DialConfig) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", ctx, host, port, keepAliveTime, dialTimeout)
+	varargs := []any{ctx, host, port}
+	for _, a := range config {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Dial", varargs...)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dial indicates an expected call of Dial.
-func (mr *MockClientMockRecorder) Dial(ctx, host, port, keepAliveTime, dialTimeout any) *gomock.Call {
+func (mr *MockClientMockRecorder) Dial(ctx, host, port any, config ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), ctx, host, port, keepAliveTime, dialTimeout)
+	varargs := append([]any{ctx, host, port}, config...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), varargs...)
 }
 
 // DialTLS mocks base method.
-func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, keepAliveTime, dialTimeout *time.Duration) (Connection, error) {
+func (m *MockClient) DialTLS(ctx context.Context, host string, port int, insecureSSL bool, config ...DialConfig) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DialTLS", ctx, host, port, insecureSSL, keepAliveTime, dialTimeout)
+	varargs := []any{ctx, host, port, insecureSSL}
+	for _, a := range config {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DialTLS", varargs...)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DialTLS indicates an expected call of DialTLS.
-func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL, keepAliveTime, dialTimeout any) *gomock.Call {
+func (mr *MockClientMockRecorder) DialTLS(ctx, host, port, insecureSSL any, config ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), ctx, host, port, insecureSSL, keepAliveTime, dialTimeout)
+	varargs := append([]any{ctx, host, port, insecureSSL}, config...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialTLS", reflect.TypeOf((*MockClient)(nil).DialTLS), varargs...)
 }

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -60,9 +60,11 @@ func TestDial(t *testing.T) {
 	// Test successful connection
 	t.Run("Dial", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		dialTimeout := 5 * time.Second
-		keepAliveTime := 10 * time.Second
-		conn, err := c.Dial(context.Background(), host, port, &keepAliveTime, &dialTimeout)
+		config := DialConfig{
+			KeepAliveTime: 10 * time.Second,
+			DialTimeout:   5 * time.Second,
+		}
+		conn, err := c.Dial(context.Background(), host, port, config)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 		assert.True(t, conn.MaxAgeTime().After(time.Now()))
@@ -72,15 +74,17 @@ func TestDial(t *testing.T) {
 	// Test connection to non-existent server
 	t.Run("DialFail", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		dialTimeout := 5 * time.Second
-		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, nil, &dialTimeout)
+		config := DialConfig{
+			DialTimeout: 5 * time.Second,
+		}
+		_, err := c.Dial(context.Background(), "127.0.0.1", 12345, config)
 		assert.Error(t, err)
 	})
 
 	// Test connection with nil timeout
 	t.Run("DialWithNilTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		conn, err := c.Dial(context.Background(), host, port, nil, nil)
+		conn, err := c.Dial(context.Background(), host, port, DialConfig{})
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -88,8 +92,10 @@ func TestDial(t *testing.T) {
 	// Test connection with zero timeout
 	t.Run("DialWithZeroTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		zeroTimeout := time.Duration(0)
-		conn, err := c.Dial(context.Background(), host, port, nil, &zeroTimeout)
+		config := DialConfig{
+			DialTimeout: time.Duration(0),
+		}
+		conn, err := c.Dial(context.Background(), host, port, config)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -100,9 +106,10 @@ func TestDial(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		dialTimeout := 5 * time.Second
-
-		_, err := c.Dial(ctx, host, port, nil, &dialTimeout)
+		config := DialConfig{
+			DialTimeout: 5 * time.Second,
+		}
+		_, err := c.Dial(ctx, host, port, config)
 		assert.Error(t, err)
 	})
 }
@@ -161,9 +168,11 @@ func TestDialTLS(t *testing.T) {
 	// Test successful TLS connection with insecure SSL
 	t.Run("DialTLS", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		dialTimeout := 5 * time.Second
-		keepAliveTime := 10 * time.Second
-		conn, err := c.DialTLS(context.Background(), host, port, true, &keepAliveTime, &dialTimeout)
+		config := DialConfig{
+			KeepAliveTime: 10 * time.Second,
+			DialTimeout:   5 * time.Second,
+		}
+		conn, err := c.DialTLS(context.Background(), host, port, true, config)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 		assert.True(t, conn.MaxAgeTime().After(time.Now()))
@@ -172,15 +181,17 @@ func TestDialTLS(t *testing.T) {
 	// Test TLS connection with secure SSL (should fail with self-signed cert)
 	t.Run("DialTLSSecure", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		dialTimeout := 5 * time.Second
-		_, err := c.DialTLS(context.Background(), host, port, false, nil, &dialTimeout)
+		config := DialConfig{
+			DialTimeout: 5 * time.Second,
+		}
+		_, err := c.DialTLS(context.Background(), host, port, false, config)
 		assert.Error(t, err)
 	})
 
 	// Test TLS connection with nil timeout
 	t.Run("DialTLSWithNilTimeout", func(t *testing.T) {
 		c := &client{keepAliveTime: 5 * time.Second}
-		conn, err := c.DialTLS(context.Background(), host, port, true, nil, nil)
+		conn, err := c.DialTLS(context.Background(), host, port, true, DialConfig{})
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -192,9 +203,10 @@ func TestDialTLS(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		dialTimeout := 5 * time.Second
-
-		_, err := c.DialTLS(ctx, host, port, true, nil, &dialTimeout)
+		config := DialConfig{
+			DialTimeout: 5 * time.Second,
+		}
+		_, err := c.DialTLS(ctx, host, port, true, config)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
This pull request refactors the `Dial` and `DialTLS` methods in the `nntp` package to use a new `DialConfig` struct instead of individual parameters for `keepAliveTime` and `dialTimeout`. This change simplifies the method signatures and improves code readability.

Key changes include:

### Introduction of `DialConfig` struct:
* [`nntp.go`](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265R12-R16): Added `DialConfig` struct to encapsulate `KeepAliveTime` and `DialTimeout` parameters.

### Refactoring method signatures:
* [`nntp.go`](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L22-R34): Updated `Dial` and `DialTLS` method signatures to accept `DialConfig` as a variadic parameter. [[1]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L22-R34) [[2]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L124-R134)

### Implementation changes:
* [`nntp.go`](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L68-R77): Modified `Dial` and `DialTLS` methods to extract values from `DialConfig` and use them in the connection setup. [[1]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L68-R77) [[2]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L87-R92) [[3]](diffhunk://#diff-b2ad87835337c7f9075c6d768e3a8a20bf076e6860b80426adb6cb4297593265L143-R149)

### Mock updates:
* [`nntp_mock.go`](diffhunk://#diff-4d54d5eff955c35e5cf4e7cd3a79628026f96e2e750df093709b02917ec278c3L45-R80): Updated mock methods to reflect changes in the `Dial` and `DialTLS` method signatures. [[1]](diffhunk://#diff-4d54d5eff955c35e5cf4e7cd3a79628026f96e2e750df093709b02917ec278c3L45-R80) [[2]](diffhunk://#diff-4d54d5eff955c35e5cf4e7cd3a79628026f96e2e750df093709b02917ec278c3L15)

### Test updates:
* [`nntp_test.go`](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL63-R67): Refactored tests to use `DialConfig` when calling `Dial` and `DialTLS`. [[1]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL63-R67) [[2]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL75-R98) [[3]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL103-R112) [[4]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL164-R175) [[5]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL175-R194) [[6]](diffhunk://#diff-51fdedec34e252a953c11878c06aba49901f1f3ddbe0223cc406b0a74882362aL195-R209)