### PR TITLE
fix: implement ArticleBodyReader and update related methods for Yenc header support

### DIFF
--- a/bodyreader.go
+++ b/bodyreader.go
@@ -1,0 +1,102 @@
+package nntpcli
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/mnightingale/rapidyenc"
+)
+
+type YencHeaders struct {
+	FileName   string
+	FileSize   int64
+	PartNumber int64
+	TotalParts int64
+	Offset     int64
+	PartSize   int64
+	Hash       uint32
+}
+
+type ArticleBodyReader interface {
+	io.ReadCloser
+	GetYencHeaders() (YencHeaders, error)
+}
+
+type articleBodyReader struct {
+	decoder     *rapidyenc.Decoder
+	conn        *connection
+	responseID  uint
+	buffer      *bytes.Buffer
+	headersRead bool
+	yencHeaders *YencHeaders
+	closed      bool
+}
+
+func (r *articleBodyReader) Read(p []byte) (n int, err error) {
+	if r.closed {
+		return 0, io.EOF
+	}
+
+	if r.buffer != nil && r.buffer.Len() > 0 {
+		n, err = r.buffer.Read(p)
+		if r.buffer.Len() == 0 {
+			r.buffer = nil
+		}
+		if n > 0 || err != nil {
+			return n, err
+		}
+	}
+
+	return r.decoder.Read(p)
+}
+
+func (r *articleBodyReader) GetYencHeaders() (YencHeaders, error) {
+	if r.yencHeaders != nil {
+		return *r.yencHeaders, nil
+	}
+
+	if !r.headersRead {
+		buf := make([]byte, 4096)
+		n, err := r.decoder.Read(buf)
+		if n > 0 {
+			r.buffer = bytes.NewBuffer(buf[:n])
+		}
+		r.headersRead = true
+
+		if err != nil && err != io.EOF {
+			return YencHeaders{}, err
+		}
+	}
+
+	r.yencHeaders = &YencHeaders{
+		FileName:   r.decoder.Meta.FileName,
+		FileSize:   r.decoder.Meta.FileSize,
+		PartNumber: r.decoder.Meta.PartNumber,
+		TotalParts: r.decoder.Meta.TotalParts,
+		Offset:     r.decoder.Meta.Offset,
+		PartSize:   r.decoder.Meta.PartSize,
+		Hash:       r.decoder.Meta.Hash,
+	}
+
+	return *r.yencHeaders, nil
+}
+
+func (r *articleBodyReader) Close() error {
+	if r.closed {
+		return nil
+	}
+
+	r.closed = true
+
+	if r.decoder != nil {
+		_, _ = io.Copy(io.Discard, r.decoder)
+		rapidyenc.ReleaseDecoder(r.decoder)
+		r.decoder = nil
+	}
+
+	if r.conn != nil {
+		r.conn.conn.EndResponse(r.responseID)
+	}
+
+	return nil
+}

--- a/connection_mock.go
+++ b/connection_mock.go
@@ -71,10 +71,10 @@ func (mr *MockConnectionMockRecorder) BodyDecoded(msgID, w, discard any) *gomock
 }
 
 // BodyReader mocks base method.
-func (m *MockConnection) BodyReader(msgID string) (io.ReadCloser, error) {
+func (m *MockConnection) BodyReader(msgID string) (ArticleBodyReader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BodyReader", msgID)
-	ret0, _ := ret[0].(io.ReadCloser)
+	ret0, _ := ret[0].(ArticleBodyReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -152,10 +152,7 @@ func TestArticleBodyReader_GetYencHeaders(t *testing.T) {
 		_ = reader.Close()
 	}()
 
-	articleReader, ok := reader.(*ArticleBodyReader)
-	assert.True(t, ok)
-
-	headers, err := articleReader.GetYencHeaders()
+	headers, err := reader.GetYencHeaders()
 	assert.NoError(t, err)
 	assert.Equal(t, "webutils_pl", headers.FileName)
 	assert.Equal(t, int64(9), headers.FileSize)
@@ -173,10 +170,7 @@ func TestArticleBodyReader_GetYencHeaders_ReturnsBufferedData(t *testing.T) {
 		_ = reader.Close()
 	}()
 
-	articleReader, ok := reader.(*ArticleBodyReader)
-	assert.True(t, ok)
-
-	_, err = articleReader.GetYencHeaders()
+	_, err = reader.GetYencHeaders()
 	assert.NoError(t, err)
 
 	buf := make([]byte, 1024)
@@ -243,10 +237,7 @@ func TestArticleBodyReader_ReadAfterGetYencHeaders(t *testing.T) {
 		_ = reader.Close()
 	}()
 
-	articleReader, ok := reader.(*ArticleBodyReader)
-	assert.True(t, ok)
-
-	headers, err := articleReader.GetYencHeaders()
+	headers, err := reader.GetYencHeaders()
 	assert.NoError(t, err)
 	assert.Equal(t, "webutils_pl", headers.FileName)
 


### PR DESCRIPTION
This pull request refactors the `ArticleBodyReader` implementation to improve encapsulation and streamline its usage. The changes involve moving the `ArticleBodyReader` and `YencHeaders` types into a new dedicated file, updating the `Connection` interface and its implementations, and adjusting related tests and mocks accordingly.

### Refactoring and Encapsulation:

* Moved the `ArticleBodyReader` and `YencHeaders` types into a new file, `bodyreader.go`, and implemented the `ArticleBodyReader` as a concrete type with methods for reading and retrieving Yenc headers. (`bodyreader.go`, [bodyreader.goR1-R102](diffhunk://#diff-64dc74c1b56db41bfa0dbd46dbea884ee1587147d3348fc76145a23bbf87812aR1-R102))

* Updated the `Connection` interface to use the new `ArticleBodyReader` type instead of `io.ReadCloser` for the `BodyReader` method, ensuring type safety and better encapsulation. (`connection.go`, [connection.goL23-L119](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L23-L119))

### Code Simplification:

* Removed the redundant inline implementation of `ArticleBodyReader` from `connection.go` and replaced it with the new implementation in `bodyreader.go`. (`connection.go`, [[1]](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L23-L119) [[2]](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L286-R196)

### Test and Mock Updates:

* Updated the `MockConnection` and its `BodyReader` method in `connection_mock.go` to use the new `ArticleBodyReader` type. (`connection_mock.go`, [connection_mock.goL74-R77](diffhunk://#diff-f3d181dba46a6e46d0ab20d5b9a1d5ff7fab556290c9bea80372c7726d6e3a94L74-R77))

* Simplified test cases in `connection_test.go` by removing type assertions for `ArticleBodyReader` and directly calling methods on the returned `ArticleBodyReader` interface. (`connection_test.go`, [[1]](diffhunk://#diff-b490092874a7d23daa711d51e772d0e7196b4337067351af81b448c6901ce377L155-R155) [[2]](diffhunk://#diff-b490092874a7d23daa711d51e772d0e7196b4337067351af81b448c6901ce377L176-R173) [[3]](diffhunk://#diff-b490092874a7d23daa711d51e772d0e7196b4337067351af81b448c6901ce377L246-R240)

### Miscellaneous:

* Fixed the `go:generate` directive for generating mocks in `connection.go` to use `go tool mockgen` instead of a relative path. (`connection.go`, [connection.goL1-L5](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L1-L5))