### PR TITLE
fix: enhance metrics tracking for article downloads and postings

### DIFF
--- a/bodyreader.go
+++ b/bodyreader.go
@@ -23,6 +23,7 @@ type ArticleBodyReader interface {
 }
 
 type articleBodyReader struct {
+	metrics     *Metrics
 	decoder     *rapidyenc.Decoder
 	conn        *connection
 	responseID  uint
@@ -43,11 +44,18 @@ func (r *articleBodyReader) Read(p []byte) (n int, err error) {
 			r.buffer = nil
 		}
 		if n > 0 || err != nil {
+			r.metrics.RecordDownload(int64(n))
+
 			return n, err
 		}
 	}
 
-	return r.decoder.Read(p)
+	n, err = r.decoder.Read(p)
+	if n > 0 {
+		r.metrics.RecordDownload(int64(n))
+	}
+
+	return n, err
 }
 
 func (r *articleBodyReader) GetYencHeaders() (YencHeaders, error) {

--- a/connection.go
+++ b/connection.go
@@ -212,6 +212,7 @@ func (c *connection) BodyReader(msgID string) (ArticleBodyReader, error) {
 		conn:       c,
 		responseID: id,
 		closed:     false,
+		metrics:    c.metrics,
 	}, nil
 }
 
@@ -240,6 +241,7 @@ func (c *connection) Post(r io.Reader) error {
 	_, _, err = c.conn.ReadCodeLine(240)
 	if err == nil {
 		c.metrics.RecordUpload(n)
+		c.metrics.RecordArticlePosted()
 	}
 
 	return err

--- a/metrics.go
+++ b/metrics.go
@@ -18,6 +18,7 @@ type Metrics struct {
 	bytesDownloaded   int64
 	bytesUploaded     int64
 	articlesRetrieved int64
+	articlesPosted    int64
 	authAttempts      int64
 	authFailures      int64
 	groupJoins        int64
@@ -98,6 +99,14 @@ func (m *Metrics) RecordArticle() {
 	atomic.AddInt64(&m.articlesRetrieved, 1)
 }
 
+func (m *Metrics) RecordArticlePosted() {
+	if !m.IsEnabled() {
+		return
+	}
+	atomic.StoreInt64(&m.lastActivity, time.Now().Unix())
+	atomic.AddInt64(&m.articlesPosted, 1)
+}
+
 func (m *Metrics) RecordGroupJoin() {
 	if !m.IsEnabled() {
 		return
@@ -116,6 +125,7 @@ type MetricsSnapshot struct {
 	BytesDownloaded   int64     `json:"bytes_downloaded"`
 	BytesUploaded     int64     `json:"bytes_uploaded"`
 	ArticlesRetrieved int64     `json:"articles_retrieved"`
+	ArticlesPosted    int64     `json:"articles_posted"`
 	AuthAttempts      int64     `json:"auth_attempts"`
 	AuthFailures      int64     `json:"auth_failures"`
 	GroupJoins        int64     `json:"group_joins"`
@@ -152,6 +162,7 @@ func (m *Metrics) GetSnapshot() MetricsSnapshot {
 		BytesDownloaded:   atomic.LoadInt64(&m.bytesDownloaded),
 		BytesUploaded:     atomic.LoadInt64(&m.bytesUploaded),
 		ArticlesRetrieved: atomic.LoadInt64(&m.articlesRetrieved),
+		ArticlesPosted:    atomic.LoadInt64(&m.articlesPosted), // Assuming articles posted is same as retrieved for simplicity
 		AuthAttempts:      authAttempts,
 		AuthFailures:      authFailures,
 		GroupJoins:        atomic.LoadInt64(&m.groupJoins),


### PR DESCRIPTION
This pull request introduces enhancements to the metrics tracking system and updates the `articleBodyReader` to improve download and upload tracking. The key changes include adding new metrics for tracking posted articles, integrating metrics into the `articleBodyReader`, and ensuring consistent updates to the metrics during operations.

### Enhancements to metrics tracking:

* `metrics.go`:
  - Added a new field `articlesPosted` to the `Metrics` and `MetricsSnapshot` structs for tracking the number of articles posted. [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R21) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R128)
  - Introduced a new method `RecordArticlePosted` in `Metrics` to increment the `articlesPosted` counter and update the last activity timestamp.
  - Updated the `GetSnapshot` method to include `articlesPosted` in the metrics snapshot.

### Integration of metrics into `articleBodyReader`:

* `bodyreader.go`:
  - Added a `metrics` field to the `articleBodyReader` struct to enable tracking of downloaded bytes.
  - Updated the `Read` method to record the number of bytes downloaded using the `metrics` object.

### Updates to connection operations:

* `connection.go`:
  - Passed the `metrics` object from the `connection` struct to the `articleBodyReader` during its initialization.
  - Updated the `Post` method to record both the number of bytes uploaded and the number of articles posted.